### PR TITLE
Add Apollo graphql dependancies and client side setup

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -13,7 +13,14 @@
     "dev": "cross-env NODE_ENV=development webpack-dev-server -w"
   },
   "dependencies": {
-    "extract-text-webpack-plugin": "^4.0.0-beta.0"
+    "@apollo/react-hooks": "^3.1.3",
+    "apollo-cache-inmemory": "^1.6.3",
+    "apollo-client": "^2.6.4",
+    "apollo-link-http": "^1.5.16",
+    "extract-text-webpack-plugin": "^4.0.0-beta.0",
+    "graphql": "^14.5.8",
+    "graphql-tag": "^2.10.1",
+    "react-apollo": "^3.1.3"
   },
   "devDependencies": {
     "@types/copy-webpack-plugin": "^5.0.0",

--- a/packages/client/src/index.tsx
+++ b/packages/client/src/index.tsx
@@ -5,7 +5,26 @@ import ReactDOM from 'react-dom';
 
 import { AppRouter } from './router/AppRouter';
 
+import { ApolloProvider } from '@apollo/react-hooks';
+import { ApolloClient } from 'apollo-client';
+import { InMemoryCache } from 'apollo-cache-inmemory';
+import { HttpLink } from 'apollo-link-http';
+
+const cache = new InMemoryCache();
+
+const PORT = process.env.PORT || 4000;
+const link = new HttpLink({
+  uri: `http://localhost:${PORT}/`
+});
+
+const client = new ApolloClient({
+  cache,
+  link
+})
+
 ReactDOM.render(
-  <AppRouter />,
+  <ApolloProvider client={client}>
+    <AppRouter />
+  </ApolloProvider>,
   document.getElementById('root')
 );


### PR DESCRIPTION
Adds Client Side dependencies Apollo offers along with setup of client side connection to the server side API with Apollo's ApolloProvider. Also adds react-hook helpers for querying through @apollo/react-hooks.