### PR TITLE
fix: Correction for the developer access procedure

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -5,7 +5,8 @@ But don't worry, it's very easy! This guide will help you with that.
 
 
 ## Step 1: Create your app
-- Head over to (https://github.com/settings/developers)[https://github.com/settings/developers]
+- In the upper-right corner of any page, click your profile photo, then click **Settings**.
+In the left sidebar, click **Developer settings**. In the left sidebar, click **OAuth Apps**.  
 - Click the button `New OAuth App`
 - Fill the form with:
   - Application name: `Project CM`


### PR DESCRIPTION
The link provided to access the developer settings is wrong.  I add the procedure commented on https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/